### PR TITLE
Bump version to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pqrs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pqrs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Manoj Karthick"]
 description = "Apache Parquet command-line tools and utilities"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ brew tap manojkarthick/pqrs
 brew install pqrs
 ```
 
+#### Using cargo
+
+`pqrs` is also available for installation from [crates.io](https://crates.io/crates/pqrs) using `cargo`, the rust package manager.
+
+```shell script
+cargo install pqrs
+```
+
 #### Using nix
 
 If you are a [nix](https://github.com/NixOS/nix) user, you can install `pqrs` from [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/pqrs/default.nix)
@@ -46,7 +54,7 @@ The below snippet shows the available subcommands:
 
 ```
 ❯ pqrs --help
-pqrs 0.1.1
+pqrs 0.1.2
 Manoj Karthick
 Apache Parquet command-line utility
 
@@ -218,5 +226,5 @@ Compressed Size: 12 KiB
 
 ### TODO
 
-* [ ] Add crate
+* [x] Add crate
 * [ ] Test on Windows


### PR DESCRIPTION
This version does not provide any new features or bug fixes. It's mostly an update to use official parquet and arrow crates published on crates.io - this also means that pqrs is now installable via cargo!