### PR TITLE
feat: compression info in schema subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,8 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c107a57b5913d852da9d5a40e280e4695f2258b5b87733c13b770c63a7117287"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "ahash",
  "arrow-arith",
@@ -127,9 +126,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace6aa3d5617c5d03041a05e01c6819428a8ddf49dd0b055df9b40fef9d96094"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -142,9 +140,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a04520692cc674e6afd7682f213ca41f9b13ff1873f63a5a2857a590b87b3"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -159,9 +156,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c875bcb9530ec403998fb0b2dc6d180a7c64563ca4bc22b90eafb84b113143"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "half",
  "num",
@@ -169,9 +165,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d6e18281636c8fc0b93be59834da6bf9a72bb70fd0c98ddfdaf124da466c28"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -185,9 +180,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197dab0963a236ff8e7c82e2272535745955ac1321eb740c29f2f88b353f54e"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -204,9 +198,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb68113d6ecdbe8bba48b2c4042c151bf9e1c61244e45072a50250a6fc59bafe"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -216,9 +209,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab4bbf2dd3078facb5ce0a9641316a64f42bfd8cf357e6775c8a5e6708e3a8d"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -230,9 +222,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c5b650d23746a494665d914a7fa3d21d939153cff9d53bdebe39bffa88f263"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -250,9 +241,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c6fce28e5011e30acc7466b5efcb8ed0197c396240bd2b10e167f275a3c208"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -265,9 +255,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20a421f19799d8b93eb8edde5217e910fa1e2d6ceb3c529f000e57b6db144c0"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -280,15 +269,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc85923d8d6662cc66ac6602c7d1876872e671002d60993dfdf492a6badeae92"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 
 [[package]]
 name = "arrow-select"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ab6613ce65b61d85a3410241744e84e48fbab0fe06e1251b4429d21b3470fd"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -299,9 +286,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3008641239e884aefba66d8b8532da6af40d14296349fcc85935de4ba67b89e"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -309,7 +295,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1118,9 +1104,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbd51311f8d9ff3d2697b1522b18a588782e097d313a1a278b0faf2ccf2d3f6"
+version = "39.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=0e9bdd651fffff155f6c38be692e4242d7f58577#0e9bdd651fffff155f6c38be692e4242d7f58577"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1348,7 +1333,7 @@ checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1356,12 +1341,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ categories = ["command-line-utilities"]
 thiserror = "1.0.30"
 log = "0.4.16"
 env_logger = "0.9.0"
-parquet = { version = "38.0.0", features = ["cli"] }
-arrow = { version = "38.0.0", features = ["chrono-tz"] }
-clap = { version = "4.2.7", features = ["derive"]}
+# TODO: Update `parquet` and `arrow` to `40.0.0` when they are released
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "0e9bdd651fffff155f6c38be692e4242d7f58577", features = ["cli"] }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "0e9bdd651fffff155f6c38be692e4242d7f58577", features = ["chrono-tz"] }
+clap = { version = "4.2.7", features = ["derive"] }
 rand = "0.8.5"
 walkdir = "2.3.2"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
# What does this PR do
1. Add compression information to `pqrs schema -D`
    ```shell
    $ pqrs cat 1.parquet

    ###############
    File: 1.parquet
    ###############

    {age: 18, name: "steve", timestamp: 0}


    $ ./target/debug/pqrs schema 1.parquet -D
    ...
    column 0:
    --------------------------------------------------------------------------------
    column type: INT64
    column path: "age"
    encodings: PLAIN RLE
    file path: N/A
    file offset: 57
    num of values: 1
    compression: UNCOMPRESSED
    total compressed size (in bytes): 53
    total uncompressed size (in bytes): 53
    data page offset: 4
    index page offset: N/A
    dictionary page offset: N/A
    statistics: {min: 18, max: 18, distinct_count: N/A, null_count: 0, min_max_deprecated: false}
    bloom filter offset: N/A
    offset index offset: 423
    offset index length: 10
    column index offset: 336
    column index length: 31


    column 1:
    --------------------------------------------------------------------------------
    column type: BYTE_ARRAY
    column path: "name"
    encodings: PLAIN RLE
    file path: N/A
    file offset: 170
    num of values: 1
    compression: UNCOMPRESSED
    total compressed size (in bytes): 48
    total uncompressed size (in bytes): 48
    data page offset: 122
    index page offset: N/A
    dictionary page offset: N/A
    statistics: {min: [115, 116, 101, 118, 101], max: [115, 116, 101, 118, 101], distinct_count: N/A, null_count: 0, min_max_deprecated: false}
    bloom filter offset: N/A
    offset index offset: 433
    offset index length: 11
    column index offset: 367
    column index length: 25


    column 2:
    --------------------------------------------------------------------------------
    column type: INT64
    column path: "timestamp"
    encodings: PLAIN RLE
    file path: N/A
    file offset: 264
    num of values: 1
    compression: UNCOMPRESSED
    total compressed size (in bytes): 53
    total uncompressed size (in bytes): 53
    data page offset: 211
    index page offset: N/A
    dictionary page offset: N/A
    statistics: {min: 0, max: 0, distinct_count: N/A, null_count: 0, min_max_deprecated: false}
    bloom filter offset: N/A
    offset index offset: 444
    offset index length: 11
    column index offset: 392
    column index length: 31
    ```

Closes #40    