### PR TITLE
preserve order in cat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.5"
 walkdir = "2.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+linked_hash_set = "0.1.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -4,7 +4,6 @@ use crate::utils::Formats;
 use crate::utils::{check_path_present, is_hidden, open_file, print_rows};
 use clap::Parser;
 use log::debug;
-use std::collections::HashSet;
 use std::fs::metadata;
 use std::path::PathBuf;
 use walkdir::WalkDir;
@@ -45,7 +44,7 @@ pub(crate) fn execute(opts: CatCommandArgs) -> Result<(), PQRSError> {
     );
 
     let mut directories = vec![];
-    let mut files = HashSet::new();
+    let mut files = linked_hash_set::LinkedHashSet::new();
     for location in &opts.locations {
         let meta = metadata(location).unwrap();
         if meta.is_dir() {


### PR DESCRIPTION
The order of HashSet is random, so when I cat multiple files its always different. This change will preserve the original order.