### PR TITLE
Support quiet option for cat subcommand

### DIFF
--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -23,6 +23,10 @@ pub struct CatCommandArgs {
     #[arg(short, long, conflicts_with = "csv")]
     json: bool,
 
+    /// show help message or not
+    #[arg(short, long)]
+    quiet: bool,
+
     /// Parquet files or folders to read from
     locations: Vec<PathBuf>,
 }
@@ -84,9 +88,11 @@ pub(crate) fn execute(opts: CatCommandArgs) -> Result<(), PQRSError> {
         let file = open_file(file_name)?;
         let info_string = format!("File: {}", file_name.display());
         let length = info_string.len();
-        eprintln!("\n{}", "#".repeat(length));
-        eprintln!("{}", info_string);
-        eprintln!("{}\n", "#".repeat(length));
+        if !opts.quiet {
+            eprintln!("\n{}", "#".repeat(length));
+            eprintln!("{}", info_string);
+            eprintln!("{}\n", "#".repeat(length));
+        }
         print_rows(file, None, format)?;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -77,6 +77,24 @@ mod integration {
     }
 
     #[test]
+    fn validate_cat_quiet() -> Result<(), Box<dyn std::error::Error>> {
+        // csv quiet did not show the message
+        let mut cmd = Command::cargo_bin("pqrs")?;
+        cmd.arg("cat").arg(SIMPLE_PARQUET_PATH).arg("--csv");
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains(SIMPLE_PARQUET_PATH).not());
+
+        // json quiet did not show the message
+        cmd = Command::cargo_bin("pqrs")?;
+        cmd.arg("cat").arg(SIMPLE_PARQUET_PATH).arg("--json");
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains(SIMPLE_PARQUET_PATH).not());
+        Ok(())
+    }
+
+    #[test]
     fn validate_cat_csv_no_header() -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = Command::cargo_bin("pqrs")?;
         cmd.arg("cat")


### PR DESCRIPTION
After this option is enabled, we can send the result to other commands using pipe

This wants to support the feature requested in #35 .

PS: currently we can redirect the stderr elsewhere, and then pipe the result to the other command, but I think adding an option is a good solution because not everyone know this

cc @manojkarthick