### PR TITLE
Add --nested-fields={error,omit,json} for CSV

### DIFF
--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -1,7 +1,7 @@
 use crate::errors::PQRSError;
 use crate::errors::PQRSError::FileNotFound;
-use crate::utils::Formats;
 use crate::utils::{check_path_present, is_hidden, open_file, print_rows};
+use crate::utils::{Formats, NestedFieldFormat};
 use clap::Parser;
 use log::debug;
 use std::fs::metadata;
@@ -23,6 +23,10 @@ pub struct CatCommandArgs {
     #[arg(short, long, conflicts_with = "csv")]
     json: bool,
 
+    /// How to handle nested fields in CSV output
+    #[arg(long, requires = "csv", default_value = "error")]
+    nested_fields: NestedFieldFormat,
+
     /// Parquet files or folders to read from
     locations: Vec<PathBuf>,
 }
@@ -31,9 +35,9 @@ pub(crate) fn execute(opts: CatCommandArgs) -> Result<(), PQRSError> {
     let format = if opts.json {
         Formats::Json
     } else if opts.csv_no_header {
-        Formats::CsvNoHeader
+        Formats::CsvNoHeader(opts.nested_fields)
     } else if opts.csv {
-        Formats::Csv
+        Formats::Csv(opts.nested_fields)
     } else {
         Formats::Default
     };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,4 +33,8 @@ pub enum PQRSError {
     UTF8ConvertError(#[from] FromUtf8Error),
     #[error("Could not read/write to buffer")]
     BufferWriteError(#[from] IntoInnerError<BufWriter<Vec<u8>>>),
+    #[error(
+        "Columns encountered with nested field types, which are not supported in CSV: {0:?}\nHint: Use `--nested-fields=omit` to omit them, or `--nested-fields=json` to encode them as JSON.",
+    )]
+    NestedFieldsError(Vec<String>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, Subcommand};
-
-use crate::errors::PQRSError;
+use std::process::ExitCode;
 
 mod commands;
 mod errors;
@@ -29,7 +28,7 @@ struct Args {
     command: Commands,
 }
 
-fn main() -> Result<(), PQRSError> {
+fn main() -> ExitCode {
     let args = Args::parse();
 
     if args.debug {
@@ -39,15 +38,20 @@ fn main() -> Result<(), PQRSError> {
 
     log::debug!("args: {:?}", args);
 
-    match args.command {
-        Commands::Cat(opts) => commands::cat::execute(opts)?,
-        Commands::Head(opts) => commands::head::execute(opts)?,
-        Commands::Merge(opts) => commands::merge::execute(opts)?,
-        Commands::RowCount(opts) => commands::rowcount::execute(opts)?,
-        Commands::Sample(opts) => commands::sample::execute(opts)?,
-        Commands::Schema(opts) => commands::schema::execute(opts)?,
-        Commands::Size(opts) => commands::size::execute(opts)?,
-    }
+    let result = match args.command {
+        Commands::Cat(opts) => commands::cat::execute(opts),
+        Commands::Head(opts) => commands::head::execute(opts),
+        Commands::Merge(opts) => commands::merge::execute(opts),
+        Commands::RowCount(opts) => commands::rowcount::execute(opts),
+        Commands::Sample(opts) => commands::sample::execute(opts),
+        Commands::Schema(opts) => commands::schema::execute(opts),
+        Commands::Size(opts) => commands::size::execute(opts),
+    };
 
-    Ok(())
+    if let Err(error) = result.as_ref() {
+        eprintln!("{}", error);
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -267,7 +267,14 @@ fn array_to_json(array: ArrayRef) -> ArrayRef {
     let mut builder = StringBuilder::with_capacity(array_len, 0);
     for line in buf_str.lines() {
         // Format is {"":VALUE}
-        builder.append_value(&line[4..line.len() - 1]);
+        // Nulls are encoded as {}
+        if line.starts_with(r#"{"":"#) && line.ends_with("}") {
+            builder.append_value(&line[4..line.len() - 1]);
+        } else if line == "{}" {
+            builder.append_null();
+        } else {
+            panic!("unexpected JSON output {:?}", line);
+        }
     }
     assert_eq!(array_len, builder.len());
 


### PR DESCRIPTION
These apply to both `cat` and `head` subcommands, and specify how to handle nested fields if the output format is CSV (which does not support nested fields). The default, `--nested-fields=error`, just exits with a helpful error message.

This also changes the printing of errors escaping from the `main()` function to use `Display`, rather than `Debug`, in order to make them more user-friendly:
```
Columns encountered with nested field types, which are not supported in CSV: ["country"]
Hint: Use `--nested-fields=omit` to omit them, or `--nested-fields=json` to encode them as JSON.
```

Fixes #54.